### PR TITLE
updated factory creation example

### DIFF
--- a/resources/views/laravel-modules/v6/advanced-tools/artisan-commands.md
+++ b/resources/views/laravel-modules/v6/advanced-tools/artisan-commands.md
@@ -271,7 +271,7 @@ php artisan module:route-provider Blog
 Generate the given database factory for the specified module.
 
 ```bash
-php artisan module:make-factory FactoryName Blog
+php artisan module:make-factory ModelName Blog
 ```
 
 ### module:make-policy


### PR DESCRIPTION
as of nWidart/laravel-modules#1100 the factory generation command takes the model name as argument rather than the factory name

before `php artisan module:make-factory PostFactory Blog`
after `php artisan module:make-factory Post Blog`